### PR TITLE
When canceling, use --quiet instead -q

### DIFF
--- a/sinteractive
+++ b/sinteractive
@@ -31,7 +31,7 @@ if [ $sbatch_status -ne 0 ];then
 fi
 
 # Make sure the job is always canceled
-trap "{ scancel -q $JOB; exit; }" SIGINT SIGTERM EXIT
+trap "{ scancel --quiet $JOB; exit; }" SIGINT SIGTERM EXIT
 
 echo "Waiting for JOBID $JOB to start"
 while true;do


### PR DESCRIPTION
- The -q option now means --qos

Other forks of `sinteractive` seem to have this since 2014 and use same fix, so this will probably work.  Deployed on Triton already.